### PR TITLE
Small timing update

### DIFF
--- a/game2048/board.py
+++ b/game2048/board.py
@@ -713,7 +713,7 @@ def on_start_game(match_id):
         match["status"] = MatchStatus.START.value
         match_state.start_match(match_id)
         emit("countdown_start", {"seconds": 3}, to=match_id)
-        socketio.sleep(3)
+        socketio.sleep(3.4)
         emit("game_state", match, to=match_id)
         match["status"] = MatchStatus.ONGOING.value
 


### PR DESCRIPTION
When the match is counting down, the user can already start moving before "Go!" has finished. Added a tiny delay before sending game state just for UX.

3.5 felt a bit too long after "Go!" has finished as the tiles are not there yet. 3.4 is just right after "Go!" making it perfect.